### PR TITLE
Fix RandomAccessInputStream position when read() for last bytes

### DIFF
--- a/dictzip-lib/src/main/java/org/dict/zip/RandomAccessInputStream.java
+++ b/dictzip-lib/src/main/java/org/dict/zip/RandomAccessInputStream.java
@@ -135,9 +135,21 @@ public class RandomAccessInputStream extends InputStream {
      */
     @Override
     public final synchronized int read() throws IOException {
-        return read(currentpos++);
+        int c = read(currentpos);
+        if (c == -1) {
+            return -1;
+        }
+        currentpos++;
+        return c;
     }
 
+    /**
+     * Read one byte from specified position.
+     * This method does not modify this stream's position.
+     * If the given position is greater than the file's current size then no bytes are read and return -1.
+     * @param pos position to read.
+     * @return -1 when position is greater than the file's current size, otherwise byte value.
+     */
     public int read(long pos) {
         if (pos < startpos || pos > endpos) {
             long blockstart = (pos/ bufsize) * bufsize;

--- a/dictzip-lib/src/test/java/org/dict/zip/RandomAccessInputStreamTest.java
+++ b/dictzip-lib/src/test/java/org/dict/zip/RandomAccessInputStreamTest.java
@@ -202,4 +202,31 @@ public class RandomAccessInputStreamTest {
         long result = instance.skip(n);
         assertEquals(result, expResult);
     }
+
+    @Test
+    public void testLastByte() throws Exception {
+        RandomAccessInputStream instance = new RandomAccessInputStream(dataFile, "r");
+        instance.seek(136854);
+        int c = instance.read();
+        assertEquals(5, c);
+        c = instance.read();
+        assertEquals(0, c);
+        c = instance.read();
+        assertEquals(-1, c);
+        long pos = instance.position();
+        assertEquals(136856, pos);
+    }
+
+    @Test
+    public void testLastBytes() throws Exception {
+        RandomAccessInputStream instance = new RandomAccessInputStream(dataFile, "r");
+        instance.seek(136848);
+        byte[] buf = new byte[9];
+        int len = instance.read(buf, 0, buf.length);
+        assertEquals(8, len);
+        assertEquals(5, buf[len - 2]);
+        assertEquals(0, buf[len - 1]);
+        long pos = instance.position();
+        assertEquals(136856, pos);
+    }
 }


### PR DESCRIPTION
Signed-off-by: Hiroshi Miura <miurahr@linux.com>