### PR TITLE
Fix doubled position when used readFully method

### DIFF
--- a/dictzip-lib/src/main/java/org/dict/zip/DictZipInputStream.java
+++ b/dictzip-lib/src/main/java/org/dict/zip/DictZipInputStream.java
@@ -240,7 +240,6 @@ public class DictZipInputStream extends InflaterInputStream {
                 throw new EOFException();
             }
             num += count;
-            rawOffset += count;
         }
     }
 


### PR DESCRIPTION
readFully method is implemented to use `read` method. `read` method increment position but readFully also increment. This resulted to be doubled position.